### PR TITLE
Patch apply vad is stereo and mono convert

### DIFF
--- a/vad/energy_vad.py
+++ b/vad/energy_vad.py
@@ -54,7 +54,7 @@ class EnergyVAD:
         frame_shift = self.frame_shift * self.sample_rate // 1000
 
         # Compute energy
-        energy = np.zeros((waveform.shape[0] - frame_length + frame_shift) // frame_shift)
+        energy = np.zeros((waveform.shape[0] - frame_length + frame_shift) // frame_shift + 1)
         for i in range(energy.shape[0]):
             energy[i] = np.sum(waveform[i * frame_shift : i * frame_shift + frame_length] ** 2)
 

--- a/vad/energy_vad.py
+++ b/vad/energy_vad.py
@@ -110,7 +110,6 @@ class EnergyVAD:
             bool: True if the signal was stereo, False otherwise
         '''
         if waveform.ndim == 2 and waveform.shape[1] == 2:
-            is_stereo = True
             print("Warning: stereo audio detected, using only the first channel")
             waveform = waveform.T[0].T
 

--- a/vad/energy_vad.py
+++ b/vad/energy_vad.py
@@ -92,7 +92,10 @@ class EnergyVAD:
             channel_waveform = []
             for i in range(len(vad)):
                 if vad[i] == 1:
-                    channel_waveform.extend(waveform[channel, i * shift : i * shift + shift])
+                    if is_stereo:
+                        channel_waveform.extend(waveform[channel, i * shift : i * shift + shift])
+                    else:
+                        channel_waveform.extend(waveform[i * shift : i * shift + shift])
             new_waveform.append(channel_waveform)
 
         new_waveform = np.array(new_waveform)


### PR DESCRIPTION
I removed obsolate is_stereo variable and refactor np.array design. In description is ``waveform (np.ndarray): input waveform of shape (num_samples,)`` but array shape is used like (num_channels, num_samples). I fixed it.

The Energy array is one element too less. I fixed it.
if vad[1]  != 1 now setup 0 on new_waveform. Maybe is better to initialize with nb.zeros(shape)